### PR TITLE
🐛 fix child component hmr

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -8,17 +8,19 @@
  * @author clark-t
  */
 
-// const path = require('path');
 const getHandler = require('./get-handler');
 const loaderUtils = require('loader-utils');
 const parse = require('./utils/ast-parser');
-
+ 
 module.exports = async function (source, inputSourceMap) {
     this.cachable = true;
     const callback = this.async();
     const options = loaderUtils.getOptions(this) || {};
+    const rawQuery = this.resourceQuery.slice(1);
+    const query = new URLSearchParams(rawQuery);
+    const isFakeSanFile = query.get('san') === '' && !!query.get('lang');
 
-    if (options.enable === false) {
+    if (options.enable === false || isFakeSanFile) {
         callback(null, source, inputSourceMap);
         return;
     }

--- a/lib/runtime/component-client-api.js
+++ b/lib/runtime/component-client-api.js
@@ -64,22 +64,34 @@ function injectHook(options, name, callback) {
 
 function makeComponentHot(id, ComponentClass) {
     ComponentClass = utils.esm(ComponentClass);
-
-    var proto;
     var Ctor;
 
     if (typeof ComponentClass === 'function') {
-        proto = ComponentClass.prototype;
         Ctor = ComponentClass;
     }
-    else {
-        proto = ComponentClass;
-        Ctor = San.defineComponent(proto);
+    else if (typeof ComponentClass === 'object') {
+        Ctor = San.defineComponent(ComponentClass);
+        injectHook(ComponentClass, 'attached', function () {
+            map[id].instances.push(this);
+        });
+
+        injectHook(ComponentClass, 'detached', function () {
+            var instances = map[id].instances;
+            instances.splice(instances.indexOf(this), 1);
+        });
     }
+    else {
+        throw new Error(
+            '[HMR] Unrecognized component type'
+        );
+    }
+
+    var proto = Ctor.prototype;
 
     injectHook(proto, 'attached', function () {
         map[id].instances.push(this);
     });
+
     injectHook(proto, 'detached', function () {
         var instances = map[id].instances;
         instances.splice(instances.indexOf(this), 1);

--- a/lib/runtime/component-client-api.js
+++ b/lib/runtime/component-client-api.js
@@ -64,42 +64,31 @@ function injectHook(options, name, callback) {
 
 function makeComponentHot(id, ComponentClass) {
     ComponentClass = utils.esm(ComponentClass);
-    var Ctor;
 
-    if (typeof ComponentClass === 'function') {
-        Ctor = ComponentClass;
-    }
-    else if (typeof ComponentClass === 'object') {
-        Ctor = San.defineComponent(ComponentClass);
-        injectHook(ComponentClass, 'attached', function () {
-            map[id].instances.push(this);
-        });
+    var isClassComp = typeof ComponentClass === 'function';
 
-        injectHook(ComponentClass, 'detached', function () {
-            var instances = map[id].instances;
-            instances.splice(instances.indexOf(this), 1);
-        });
-    }
-    else {
+    if (!isClassComp && typeof ComponentClass !== 'object') {
         throw new Error(
             '[HMR] Unrecognized component type'
         );
     }
 
-    var proto = Ctor.prototype;
+    var hookTarget = isClassComp ? ComponentClass.prototype : ComponentClass;
 
-    injectHook(proto, 'attached', function () {
+    injectHook(hookTarget, 'attached', function () {
         map[id].instances.push(this);
     });
 
-    injectHook(proto, 'detached', function () {
+    injectHook(hookTarget, 'detached', function () {
         var instances = map[id].instances;
         instances.splice(instances.indexOf(this), 1);
     });
 
+    var Ctor = isClassComp ? ComponentClass : San.defineComponent(ComponentClass);
+
     return {
-        proto: proto,
-        Ctor: Ctor
+        Ctor,
+        proto: Ctor.prototype
     };
 }
 


### PR DESCRIPTION
修复单文件组件只能热更新一次的问题
1. 组件模块可能是object，而不一定是Component；
2. object被修改了，决定了初始的组件首次有了热更新的逻辑；
3. 不能继续热更新，是因为后续的object更新了，只是在操作对象（object.dispose），它并不能触发detached生命周期钩子方法，而不是操作组件。